### PR TITLE
Fix tabs used as space between operands.

### DIFF
--- a/SequenceFile.cs
+++ b/SequenceFile.cs
@@ -443,7 +443,7 @@ namespace GotaSequenceLib {
             List<string> t = text.ToList();
             int comNum = 0;
             for (int i = t.Count - 1; i >= 0; i--) {
-                t[i] = t[i].Replace("\t", "").Replace("\r", "");
+                t[i] = t[i].Replace("\t", " ").Replace("\r", "");
                 try { t[i] = t[i].Split(';')[0]; } catch { }
                 if (t[i].Replace(" ", "").Length == 0) { t.RemoveAt(i); continue; }
                 for (int j = 0; j < t[i].Length; j++) {


### PR DESCRIPTION
Some people format their .rseq files as "cmd\targs". Before, tabs were
completely removed, so it was parsed as "cmdargs" instead of "cmd args".
This PR fixes that.