### PR TITLE
When rethrowing the exception, include the cause

### DIFF
--- a/SequenceFile.cs
+++ b/SequenceFile.cs
@@ -484,7 +484,7 @@ namespace GotaSequenceLib {
                     continue;
                 }
                 SequenceCommand seq = new SequenceCommand();
-                try { seq.FromString(t[i], p, PublicLabels, privateLabels); } catch { WritingCommandSuccess = false; throw new Exception("Command " + i + ": \"" + t[i] + "\" is invalid."); }
+                try { seq.FromString(t[i], p, PublicLabels, privateLabels); } catch (Exception e) { WritingCommandSuccess = false; throw new Exception("Command " + i + ": \"" + t[i] + "\" is invalid.", e); }
                 Commands.Add(seq);
             }
 


### PR DESCRIPTION
This avoids throwing away the original stack-trace, which helps when
receiving crash logs from other people.